### PR TITLE
[Bugfix]Follow the standart in variabel init.

### DIFF
--- a/Ecma/Parser.php
+++ b/Ecma/Parser.php
@@ -288,9 +288,13 @@ class Parser{
   private function parseVariabelDeclaration(){
     $this->expect("identify");
     $identify = $this->token->currentToken()->value;
-    $this->token->next();
-    $this->expect("punctuator", "=");
-    $this->token->next();
+    if($this->token->next()->type == "punctuator" && $this->token->currentToken()->value == "="){
+       $this->token->next();
+       $value = $this->parseAssignmentExpression();
+    }else{
+       $value = new EmptyStatment();
+    }
+ 
     return new AssignExpresion(new IdentifyExpresion($identify), "=", $this->parseAssignmentExpression());
   }
 


### PR DESCRIPTION
Before you need to have a = in "var variabel" 
It is not correct you are allow to do it as this
"var variabel"